### PR TITLE
Add nullable returns, test if can avoid Utf8JsonReader in Deserialise()

### DIFF
--- a/.idea/.idea.Utf8JsonStreamReader/.idea/.name
+++ b/.idea/.idea.Utf8JsonStreamReader/.idea/.name
@@ -1,0 +1,1 @@
+Utf8JsonStreamReader

--- a/.idea/.idea.Utf8JsonStreamReader/.idea/aws.xml
+++ b/.idea/.idea.Utf8JsonStreamReader/.idea/aws.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/.idea.Utf8JsonStreamReader/.idea/indexLayout.xml
+++ b/.idea/.idea.Utf8JsonStreamReader/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.Utf8JsonStreamReader/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.Utf8JsonStreamReader/.idea/projectSettingsUpdater.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RiderProjectSettingsUpdater">
+    <option name="vcsConfiguration" value="2" />
+  </component>
+</project>

--- a/.idea/.idea.Utf8JsonStreamReader/.idea/vcs.xml
+++ b/.idea/.idea.Utf8JsonStreamReader/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Utf8JsonStreamReader.Test/Utf8JsonStreamReaderTests.fs
+++ b/Utf8JsonStreamReader.Test/Utf8JsonStreamReaderTests.fs
@@ -14,10 +14,10 @@ type Data =
     {
         F : string
     }
-    
+
 type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
     let serializerOptions = JsonSerializerOptions(AllowTrailingCommas=false, WriteIndented=false)
-    
+
     let streamOfString (s : string) =
         let stream = new MemoryStream(s.Length)
         do
@@ -27,7 +27,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
         stream
 
     let bufferSize = 16
-        
+
     [<Fact>]
     member this.``Ensure can roundtrip data test type without stream helper`` () =
         // make sure we'll have no problems with our trivial type
@@ -35,16 +35,16 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
         output.WriteLine <| sprintf "json: %s" json
         let v : Data = JsonSerializer.Deserialize(json, serializerOptions)
         v |> shouldEqual { F = "a" }
-        
+
     // note that buffers are typically powers of 2 even if we request < that.
     // so write these tests with that in mind
     // {"F":"abcdefgh"} is 16 chars
-    
+
     [<Fact>]
     member this.``Ensure can deserialise single object json of length = bufferSize-1`` () =
         let json = """{"F":"abcdefg"}"""
         json.Length |> shouldEqual (bufferSize-1)
-        
+
         use stream = streamOfString json
 
         let r = new Utf8JsonStreamReader(stream, bufferSize)
@@ -60,7 +60,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
     member this.``Ensure can deserialise single object json of length < bufferSize`` () =
         let json = """{"F":"abcde"}"""
         json.Length |> shouldBeSmallerThan bufferSize
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -75,7 +75,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
     member this.``Ensure can deserialise single object json of length = bufferSize`` () =
         let json = """{"F":"abcdefgh"}"""
         json.Length |> shouldEqual bufferSize
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -90,7 +90,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
     member this.``Ensure can deserialise single object json of length = bufferSize+1`` () =
         let json = """{"F":"abcdefghi"}"""
         json.Length |> shouldEqual (bufferSize+1)
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -101,7 +101,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
                 use doc = r.GetJsonDocument()
                 doc.RootElement.GetProperty("F").GetString() |> shouldEqual "abcdefghi"
             r.TokenType |> shouldEqual JsonTokenType.EndObject
-                
+
             r.Read() |> shouldEqual false
 
         finally
@@ -111,7 +111,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
     member this.``Ensure can deserialise single object json of length = bufferSize+2`` () =
         let json = """{"F":"abcdefghij"}"""
         json.Length |> shouldEqual (bufferSize+2)
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -122,7 +122,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
                 use doc = r.GetJsonDocument()
                 doc.RootElement.GetProperty("F").GetString() |> shouldEqual "abcdefghij"
             r.TokenType |> shouldEqual JsonTokenType.EndObject
-                
+
             r.Read() |> shouldEqual false
 
         finally
@@ -132,7 +132,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
     member this.``Ensure can deserialise single object json of length = bufferSize+3 - string token crossing buffer boundary`` () =
         let json = """{"F":"abcdefghijk"}"""
         json.Length |> shouldEqual (bufferSize+3)
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -143,17 +143,17 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
                 use doc = r.GetJsonDocument()
                 doc.RootElement.GetProperty("F").GetString() |> shouldEqual "abcdefghijk"
             r.TokenType |> shouldEqual JsonTokenType.EndObject
-                
+
             r.Read() |> shouldEqual false
 
         finally
-            r.Dispose()            
+            r.Dispose()
 
     [<Fact>]
     member this.``Ensure can deserialise single object json of length = bufferSize*1,5`` () =
         let json = """{"F":"abcdefghijklmnop"}"""
         json.Length |> shouldEqual (1.5 * float bufferSize |> int)
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -169,7 +169,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
         // single-char string field needs 9 chars
         let json = """{"F":"abcdefghijklmnopqrstuvwx"}"""
         json.Length |> shouldEqual (bufferSize*2)
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -185,7 +185,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
         // single-char string field needs 9 chars
         let json = """{"F":"abcdefghijklmnopqrstuvwxy"}"""
         json.Length |> shouldEqual (bufferSize*2+1)
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -201,7 +201,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
         // single-char string field needs 9 chars
         let json = """{"F":"abcdefghijklmnopqrstuvwxyzABCDEF"}"""
         json.Length |> shouldEqual (float bufferSize * 2.5 |> int)
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -211,13 +211,13 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
             r.Read() |> shouldEqual false
         finally
             r.Dispose()
-            
+
     [<Fact>]
     member this.``Ensure can deserialise single object json of length = bufferSize*3`` () =
         // single-char string field needs 9 chars
         let json = """{"F":"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN"}"""
         json.Length |> shouldEqual (float bufferSize * 3.0 |> int)
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -227,12 +227,12 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
             r.Read() |> shouldEqual false
         finally
             r.Dispose()
-            
+
     [<Fact>]
     member this.``Ensure can deserialise single element array json of length < bufferSize`` () =
         let json = """[{"F":"abc"}]"""
         json.Length |> shouldBeSmallerThan bufferSize
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -248,7 +248,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
             r.Read() |> shouldEqual false
         finally
             r.Dispose()
-                                   
+
     [<Fact>]
     member this.``Ensure can deserialise two element array json of length < bufferSize`` () =
         let json = """[{"F":"a"},{"F":"b"}]"""
@@ -272,7 +272,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
                 use doc = r.GetJsonDocument()
                 doc.RootElement.GetProperty("F").GetString() |> shouldEqual "b"
             r.TokenType |> shouldEqual JsonTokenType.EndObject
-            
+
             r.Read() |> shouldEqual true
             r.TokenType |> shouldEqual JsonTokenType.EndArray
             r.Read() |> shouldEqual false
@@ -284,7 +284,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
         let json = """[{"F":"aaaaaa"},{"F":"bbbbbbb"}]"""
         let bufferSize = 32
         json.Length |> shouldEqual bufferSize
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -303,7 +303,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
                 use doc = r.GetJsonDocument()
                 doc.RootElement.GetProperty("F").GetString() |> shouldEqual "bbbbbbb"
             r.TokenType |> shouldEqual JsonTokenType.EndObject
-            
+
             r.Read() |> shouldEqual true
             r.TokenType |> shouldEqual JsonTokenType.EndArray
             r.Read() |> shouldEqual false
@@ -314,7 +314,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
     member this.``Ensure can deserialise two element array json of length = bufferSize*2`` () =
         let json = """[{"F":"abcdef"},{"F":"bcdefgh"}]"""
         bufferSize * 2 |> shouldEqual json.Length
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -333,7 +333,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
                 use doc = r.GetJsonDocument()
                 doc.RootElement.GetProperty("F").GetString() |> shouldEqual "bcdefgh"
             r.TokenType |> shouldEqual JsonTokenType.EndObject
-            
+
             r.Read() |> shouldEqual true
             r.TokenType |> shouldEqual JsonTokenType.EndArray
             r.Read() |> shouldEqual false
@@ -343,7 +343,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
     [<Fact>]
     member this.``Ensure can deserialise when middle element spans a buffer boundary`` () =
         let json = """[{"F":"a"},{"F":"abcdefghijklmnopqrs"},{"F":"z"}]"""
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -362,7 +362,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
                 use doc = r.GetJsonDocument()
                 doc.RootElement.GetProperty("F").GetString() |> shouldEqual "abcdefghijklmnopqrs"
             r.TokenType |> shouldEqual JsonTokenType.EndObject
-            
+
             r.Read() |> shouldEqual true
             r.TokenType |> shouldEqual JsonTokenType.StartObject
             do
@@ -375,12 +375,12 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
             r.Read() |> shouldEqual false
         finally
             r.Dispose()
-            
+
     [<Fact>]
     member this.``Ensure can deserialise when middle element spans multiple buffer boundaries`` () =
         let json = """[{"F":"a"},{"F":"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"},{"F":"z"}]"""
         //            0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab
-        
+
         use stream = streamOfString json
         let r = new Utf8JsonStreamReader(stream, bufferSize)
         try
@@ -399,7 +399,7 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
                 use doc = r.GetJsonDocument()
                 doc.RootElement.GetProperty("F").GetString() |> shouldEqual "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
             r.TokenType |> shouldEqual JsonTokenType.EndObject
-            
+
             r.Read() |> shouldEqual true
             r.TokenType |> shouldEqual JsonTokenType.StartObject
             do
@@ -411,4 +411,18 @@ type Utf8JsonStreamReaderTests(output : ITestOutputHelper) =
             r.TokenType |> shouldEqual JsonTokenType.EndArray
             r.Read() |> shouldEqual false
         finally
-            r.Dispose()                    
+            r.Dispose()
+
+    [<Fact>]
+    member this.``Ensure can use Deserialise for element in more than one buffer`` () =
+        // single-char string field needs 9 chars
+        let json = """{"F":"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN"}"""
+        json.Length |> shouldEqual (float bufferSize * 3.0 |> int)
+
+        use stream = streamOfString json
+        let r = new Utf8JsonStreamReader(stream, bufferSize)
+        try
+            r.Read() |> shouldEqual true
+            r.Deserialise<Data>() |> shouldEqual { F = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN" }
+        finally
+            r.Dispose()

--- a/Utf8JsonStreamReader.sln.DotSettings.user
+++ b/Utf8JsonStreamReader.sln.DotSettings.user
@@ -1,0 +1,5 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/Highlighting/HighlightingSourceSnapshotLocation/@EntryValue">C:\Users\nick\AppData\Local\JetBrains\Rider2021.2\resharper-host\temp\Rider\vAny\CoverageData\_Utf8JsonStreamReader.-2036664375\Snapshot\snapshot.utdcvr</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=26e1992b_002D5b50_002D4ac7_002Dbf1f_002Dfcf70873e11e/@EntryIndexedValue">&lt;SessionState ContinuousTestingIsOn="True" ContinuousTestingMode="3" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;Solution /&gt;&#xD;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/Utf8JsonStreamReader/Utf8JsonStreamReader.cs
+++ b/Utf8JsonStreamReader/Utf8JsonStreamReader.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 namespace Utf8JsonStreamReader
 {
 
-    
+
     // Taken from https://stackoverflow.com/questions/54983533/parsing-a-json-file-with-net-core-3-0-system-text-json
     // and fixed a few bugs with that
     public ref struct Utf8JsonStreamReader
@@ -75,7 +75,7 @@ namespace Utf8JsonStreamReader
             var newSegment = new SequenceSegment(_bufferSize, _lastSegment);
             _lastSegment?.SetNext(newSegment);
             _lastSegment = newSegment;
-            
+
             if (_firstSegment == null)
             {
                 _firstSegment = newSegment;
@@ -116,12 +116,12 @@ namespace Utf8JsonStreamReader
                 _firstSegment = firstSegment;
                 _firstSegmentStartIndex = firstSegmentStartIndex;
                 var data = new ReadOnlySequence<byte>(_firstSegment!, _firstSegmentStartIndex, _lastSegment!,
-                    _lastSegmentEndIndex); 
+                    _lastSegmentEndIndex);
                 _jsonReader =
                     new Utf8JsonReader(data, _isFinalBlock, _jsonReader.CurrentState);
             }
         }
-        
+
         private long DeserialisePre(out SequenceSegment? firstSegment, out int firstSegmentStartIndex)
         {
             // JsonSerializer.Deserialize can read only a single object. We have to extract
@@ -154,9 +154,10 @@ namespace Utf8JsonStreamReader
         {
             var tokenStartIndex = DeserialisePre(out var firstSegment, out var firstSegmentStartIndex);
 
-            var newJsonReader =
-                new Utf8JsonReader(new ReadOnlySequence<byte>(firstSegment!, firstSegmentStartIndex, _lastSegment!,
-                    _lastSegmentEndIndex).Slice(tokenStartIndex, _jsonReader.Position), true, default);
+
+            var seq = new ReadOnlySequence<byte>(firstSegment!, firstSegmentStartIndex, _lastSegment!,
+                _lastSegmentEndIndex).Slice(tokenStartIndex, _jsonReader.Position);
+            var newJsonReader = new Utf8JsonReader(seq, true, default);
 
             // deserialize value
             var result = JsonSerializer.Deserialize<T>(ref newJsonReader, options);
@@ -176,7 +177,7 @@ namespace Utf8JsonStreamReader
 
             // deserialize value
             var result = JsonDocument.ParseValue(ref newJsonReader);
-            DeserialisePost();        
+            DeserialisePost();
             return result;
         }
 
@@ -191,7 +192,7 @@ namespace Utf8JsonStreamReader
 
         public bool GetBoolean() => _jsonReader.GetBoolean();
         public byte GetByte() => _jsonReader.GetByte();
-        public byte[] GetBytesFromBase64() => _jsonReader.GetBytesFromBase64();
+        public byte[]? GetBytesFromBase64() => _jsonReader.GetBytesFromBase64();
         public string GetComment() => _jsonReader.GetComment();
         public DateTime GetDateTime() => _jsonReader.GetDateTime();
         public DateTimeOffset GetDateTimeOffset() => _jsonReader.GetDateTimeOffset();
@@ -203,7 +204,7 @@ namespace Utf8JsonStreamReader
         public long GetInt64() => _jsonReader.GetInt64();
         public sbyte GetSByte() => _jsonReader.GetSByte();
         public float GetSingle() => _jsonReader.GetSingle();
-        public string GetString() => _jsonReader.GetString();
+        public string? GetString() => _jsonReader.GetString();
         public uint GetUInt32() => _jsonReader.GetUInt32();
         public ulong GetUInt64() => _jsonReader.GetUInt64();
         public bool TryGetByte(out byte value) => _jsonReader.TryGetByte(out value);


### PR DESCRIPTION
Changes arising from feedback from Simonl9l in Issue #8.
A couple of the accessors need nullable returns since the underlying json reader implementation can return null.

Investigated whether the Utf8JsonReader in Deserialise can be avoided, and instead just use the FirstSpan of the ReadOnlySequence, but that fails (see the new test) when the json string spans multiple buffers.